### PR TITLE
Add more test cases for sum-buddy

### DIFF
--- a/src/sumbuddy/hasher.py
+++ b/src/sumbuddy/hasher.py
@@ -4,7 +4,7 @@ class Hasher:
     def __init__(self, algorithm='md5'):
         self.algorithm = algorithm
 
-    def checksum_file(self, file_path, algorithm=None):
+    def checksum_file(self, file_path, algorithm=None, length=None):
         """
         Calculate the checksum of a file using the specified algorithm.
         
@@ -12,15 +12,55 @@ class Hasher:
         ------------
         file_path - String. Path to file to apply checksum function.
         algorithm - String. Hash function to use for checksums. Default: 'md5', see options with 'hashlib.algorithms_available'.
+        length - Integer [optional]. Length of the digest for SHAKE and BLAKE algorithms in bytes.
         
         Returns:
         ---------
-        hashlib.<algorithm>.hexdigest - String. Hash of file.
+        String. Hash of file.
+
+        Raises:
+        -------
+        ValueError - If length is provided for a fixed-length algorithm or unsupported algorithm.
         """
         if algorithm is None:
             algorithm = self.algorithm
-        hash_func = hashlib.new(algorithm)
+
+        # Validate that selected algorithm is supported
+        if algorithm not in hashlib.algorithms_available:
+            raise ValueError(f"Unsupported algorithm '{algorithm}'")
+
+        # Define variable length algorithm sets
+        shake_algorithms = {'shake_128', 'shake_256'}
+        blake_default_lengths = {'blake2s': 32, 'blake2b': 64} 
+
+        # SHAKE algorithm (requires length parameter)
+        if algorithm in shake_algorithms:
+            if length is None:
+                raise ValueError(f"Length parameter [bytes] is required for algorithm '{algorithm}'")
+            hash_func = hashlib.new(algorithm)
+        
+        # BLAKE algorithm (accepts length parameter, but defaults to standard lengths)
+        elif algorithm in blake_default_lengths:
+            if length:
+                hash_func = hashlib.new(algorithm, digest_size=length)
+            else:
+                default_length = blake_default_lengths[algorithm]
+                hash_func = hashlib.new(algorithm)
+                print(f"Using default length of {default_length} bytes for {algorithm}")
+        
+        # Other algorithms
+        else:
+            if length is not None:
+                raise ValueError(f"Length parameter is not applicable for fixed-length algorithm '{algorithm}'")
+            hash_func = hashlib.new(algorithm)
+
+        # Read the file and update the hash function
         with open(file_path, "rb") as f:
             for chunk in iter(lambda: f.read(4096), b""):
                 hash_func.update(chunk)
-        return hash_func.hexdigest()
+
+        # Return the hash digest
+        if algorithm in shake_algorithms:
+            return hash_func.hexdigest(length)
+        else:
+            return hash_func.hexdigest()

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,145 @@
+
+import unittest
+import os
+from unittest.mock import patch, MagicMock
+from sumbuddy.filter import Filter
+from sumbuddy.hasher import Hasher
+
+class TestFilter(unittest.TestCase):  
+    def setUp(self):
+        self.examples_folder = os.path.join(os.path.dirname(__file__), '..', 'examples')
+        self.example_content_folder = os.path.join(self.examples_folder, 'example_content')
+        self.expected_outputs_folder = os.path.join(self.examples_folder, 'expected_outputs')
+        
+        self.filter = Filter()
+
+        self.hasher = Hasher()
+
+    # Utilize the examples folder to test the filter class.
+    def check_output(self, ignore_filename, expected_output_filename):
+        ignore_filepath = os.path.join(self.examples_folder, ignore_filename)
+        self.filter.read_ignore_patterns(ignore_filepath=ignore_filepath)
+        
+        # Read expected output from the specified file
+        expected_output_filepath = os.path.join(self.expected_outputs_folder, expected_output_filename)
+        with open(expected_output_filepath, 'r') as f:
+            expected_output = f.read().splitlines()
+
+        # Gather actual output
+        actual_output = ['filepath,filename,md5']  
+        for root, _, files in os.walk(self.example_content_folder):
+            for file in files:
+                if file == ".DS_Store":
+                    continue
+                filepath = os.path.join(root, file)
+                include = self.filter.should_include(filepath, self.example_content_folder)
+
+                if include:
+                    filename = os.path.basename(filepath)
+                    md5_hash = self.hasher.checksum_file(filepath)
+                    relative_filepath = os.path.relpath(filepath, start=self.examples_folder)
+                    actual_output.append(f"{relative_filepath},{filename},{md5_hash}")
+        
+        expected_output.sort()
+        actual_output.sort()
+
+        self.assertEqual(expected_output, actual_output)
+
+    def test_ignore_all(self):
+        self.check_output('.sbignore_all', 'ignore_all.csv')
+    
+    def test_ignore_all_except_dots(self):
+        self.check_output('.sbignore_all_except_dots', 'ignore_all_except_dots.csv')
+
+    def test_ignore_except_txt(self):
+        self.check_output('.sbignore_except_txt', 'ignore_except_txt.csv')
+
+    def test_ignore_all_except_subdir_but_ignore_hidden(self):
+        self.check_output('.sbignore_all_except_subdir_but_ignore_hidden', 'ignore_all_except_subdir_but_ignore_hidden.csv')
+
+    def test_ignore_hidden_files(self):
+        self.check_output('.sbignore_hidden_files', 'ignore_hidden_files.csv')
+
+    def test_ignore_nothing(self):
+        self.check_output('.sbignore_nothing', 'ignore_nothing.csv')
+
+    def test_ignore_specific_file(self):
+        self.check_output('.sbignore_specific_file', 'ignore_specific_file.csv')
+
+    def test_ignore_subdir(self):
+        self.check_output('.sbignore_subdir', 'ignore_subdir.csv')
+
+    def test_ignore_txt(self):
+        self.check_output('.sbignore_txt', 'ignore_txt.csv')
+
+    # To test other hashing algorithms.
+    def check_output_with_hashing_algorithm(self, hash_algorithm, expected_output, ignore_filename):
+        ignore_filepath = os.path.join(self.examples_folder, ignore_filename)
+        self.filter.read_ignore_patterns(ignore_filepath=ignore_filepath)
+        
+        with patch.object(Hasher, 'checksum_file', return_value=hash_algorithm) as mock_method:
+            actual_output = ['filepath,filename,hash']
+            for root, _, files in os.walk(self.example_content_folder):
+                for file in files:
+                    if file == ".DS_Store":
+                        continue
+                    filepath = os.path.join(root, file)
+                    include = self.filter.should_include(filepath, self.example_content_folder)
+                    if include:
+                        filename = os.path.basename(filepath)
+                        hash_value = self.hasher.checksum_file(filepath)
+                        relative_filepath = os.path.relpath(filepath, start=self.examples_folder)
+                        actual_output.append(f"{relative_filepath},{filename},{hash_value}")
+            
+            self.assertTrue(mock_method.called)
+            
+            expected_output.sort()
+            actual_output.sort()
+
+            self.assertEqual(expected_output, actual_output)
+
+    def test_sha256(self):
+        expected_output = [
+            'filepath,filename,hash',
+            'example_content/file.txt,file.txt,sha256_hash',
+            'example_content/dir/file.txt,file.txt,sha256_hash'
+            
+        ]
+        self.check_output_with_hashing_algorithm('sha256_hash', expected_output, '.sbignore_hidden_files')
+
+    def test_shake_128(self):
+        expected_output = [
+            'filepath,filename,hash',
+            'example_content/.hidden_file,.hidden_file,shake_128',
+            'example_content/.hidden_dir/.hidden_file,.hidden_file,shake_128',
+            'example_content/dir/.hidden_file,.hidden_file,shake_128',
+            'example_content/dir/.hidden_dir/.hidden_file,.hidden_file,shake_128'
+        ]
+        self.check_output_with_hashing_algorithm('shake_128', expected_output, '.sbignore_specific_file')
+
+    def test_blake2b(self):
+        expected_output = [
+            'filepath,filename,hash',
+            'example_content/file.txt,file.txt,blake2b_hash',
+            'example_content/.hidden_dir/file.txt,file.txt,blake2b_hash',
+            'example_content/dir/file.txt,file.txt,blake2b_hash',
+            'example_content/dir/.hidden_dir/file.txt,file.txt,blake2b_hash'
+        ]
+        self.check_output_with_hashing_algorithm('blake2b_hash', expected_output, '.sbignore_except_txt')
+
+    def test_sha3_256(self):
+        expected_output = [
+            'filepath,filename,hash',
+            'example_content/.hidden_file,.hidden_file,sha3_256',
+            'example_content/file.txt,file.txt,sha3_256',
+            'example_content/.hidden_dir/.hidden_file,.hidden_file,sha3_256',
+            'example_content/.hidden_dir/file.txt,file.txt,sha3_256'        
+        ]
+        self.check_output_with_hashing_algorithm('sha3_256', expected_output, '.sbignore_subdir')
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+
+

--- a/tests/test_getChecksums.py
+++ b/tests/test_getChecksums.py
@@ -1,0 +1,106 @@
+import unittest
+from unittest.mock import patch, mock_open, MagicMock
+import os
+import sys
+import hashlib
+from io import StringIO
+
+from sumbuddy import get_checksums
+
+class TestGetChecksums(unittest.TestCase):
+
+    def setUp(self):
+        self.input_directory = 'input_dir'
+        self.output_filepath = 'output.csv'
+        self.ignore_file = 'ignore_patterns.txt'
+        self.mock_file_paths = ['file1.txt', 'file2.txt', '.hidden_file']
+        self.algorithm = 'md5'
+        self.dummy_checksum = 'dummychecksum'
+
+    @patch('os.path.abspath', side_effect=lambda x: x)
+    @patch('os.path.exists', return_value=True)
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('sumbuddy.Mapper.gather_file_paths', return_value=['file1.txt', 'file2.txt'])
+    @patch('sumbuddy.Hasher.checksum_file', side_effect=lambda x: 'dummychecksum')
+    def test_get_checksums_to_file(self, mock_checksum, mock_gather, mock_open, mock_exists, mock_abspath):
+        get_checksums(self.input_directory, self.output_filepath, ignore_file=None, include_hidden=False, algorithm=self.algorithm)
+        
+        mock_open.assert_called_with(self.output_filepath, 'w', newline='')
+        handle = mock_open()
+        handle.write.assert_any_call('filepath,filename,md5\r\n')
+        handle.write.assert_any_call('file1.txt,file1.txt,dummychecksum\r\n')
+        handle.write.assert_any_call('file2.txt,file2.txt,dummychecksum\r\n')
+        
+    @patch('os.path.abspath', side_effect=lambda x: x)
+    @patch('os.path.exists', return_value=True)
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('sumbuddy.Mapper.gather_file_paths', return_value=['file1.txt', 'file2.txt'])
+    @patch('sumbuddy.Hasher.checksum_file', side_effect=lambda x: 'dummychecksum')
+    def test_get_checksums_to_stdout(self, mock_checksum, mock_gather, mock_open, mock_exists, mock_abspath):
+        output_stream = StringIO()
+        with patch('sys.stdout', new=output_stream):
+            get_checksums(self.input_directory, output_filepath=None, ignore_file=None, include_hidden=False, algorithm=self.algorithm)
+            
+        output = output_stream.getvalue()
+        self.assertIn('filepath,filename,md5', output)
+        self.assertIn('file1.txt,file1.txt,dummychecksum', output)
+        self.assertIn('file2.txt,file2.txt,dummychecksum', output)
+        
+    @patch('os.path.abspath', side_effect=lambda x: x)
+    @patch('os.path.exists', return_value=True)
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('sumbuddy.Mapper.gather_file_paths', return_value=['file1.txt', 'file2.txt'])
+    @patch('sumbuddy.Hasher.checksum_file', side_effect=lambda x: 'dummychecksum')
+    def test_get_checksums_with_ignore_file(self, mock_checksum, mock_gather, mock_open, mock_exists, mock_abspath):
+        get_checksums(self.input_directory, output_filepath=None, ignore_file=self.ignore_file, include_hidden=False, algorithm=self.algorithm)
+        mock_gather.assert_called_with(self.input_directory, ignore_file=self.ignore_file, include_hidden=False)
+        
+    @patch('os.path.abspath', side_effect=lambda x: x)
+    @patch('os.path.exists', return_value=True)
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('sumbuddy.Mapper.gather_file_paths', return_value=['file1.txt', 'file2.txt', '.hidden_file'])
+    @patch('sumbuddy.Hasher.checksum_file', side_effect=lambda x: 'dummychecksum')
+    def test_get_checksums_include_hidden(self, mock_checksum, mock_gather, mock_open, mock_exists, mock_abspath):
+        get_checksums(self.input_directory, output_filepath=None, ignore_file=None, include_hidden=True, algorithm=self.algorithm)
+        mock_gather.assert_called_with(self.input_directory, ignore_file=None, include_hidden=True)
+        
+    @patch('os.path.abspath', side_effect=lambda x: x)
+    @patch('os.path.exists', return_value=True)
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('sumbuddy.Mapper.gather_file_paths', return_value=['file1.txt', 'file2.txt'])
+    @patch('sumbuddy.Hasher.checksum_file', side_effect=lambda x: 'dummychecksum')
+    def test_get_checksums_different_algorithm(self, mock_checksum, mock_gather, mock_open, mock_exists, mock_abspath):
+        algorithm = 'sha256'
+        get_checksums(self.input_directory, output_filepath=None, ignore_file=None, include_hidden=False, algorithm=algorithm)
+        
+        output_stream = StringIO()
+        with patch('sys.stdout', new=output_stream):
+            get_checksums(self.input_directory, output_filepath=None, ignore_file=None, include_hidden=False, algorithm=algorithm)
+            
+        output = output_stream.getvalue()
+        self.assertIn(f'filepath,filename,{algorithm}', output)
+        self.assertIn('file1.txt,file1.txt,dummychecksum', output)
+        self.assertIn('file2.txt,file2.txt,dummychecksum', output)
+
+    @patch('os.path.abspath', side_effect=lambda x: x)
+    @patch('os.path.exists', return_value=False)
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('sumbuddy.Mapper.gather_file_paths', return_value=[])
+    def test_get_checksums_empty_directory(self, mock_gather, mock_open, mock_exists, mock_abspath):
+        output_stream = StringIO()
+        with patch('sys.stdout', new=output_stream):
+            get_checksums(self.input_directory, output_filepath=None, ignore_file=None, include_hidden=False, algorithm=self.algorithm)
+            
+        output = output_stream.getvalue()
+        self.assertIn('filepath,filename,md5', output)
+
+    @patch('os.path.abspath', side_effect=lambda x: x)
+    @patch('os.path.exists', return_value=True)
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('sumbuddy.Mapper.gather_file_paths', return_value=['file1.txt', 'file2.txt'])
+    def test_get_checksums_invalid_algorithm(self, mock_gather, mock_open, mock_exists, mock_abspath):
+        with self.assertRaises(ValueError):
+            get_checksums(self.input_directory, output_filepath=None, ignore_file=None, include_hidden=False, algorithm='invalid_alg')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_hasher.py
+++ b/tests/test_hasher.py
@@ -19,7 +19,12 @@ class TestHasher(unittest.TestCase):
         "sha3_384": "1c635201d12b87839b626b26c57b81216d616c984dc42d5afa17a905402267817ac787abfc24072e18e77f921eb6a23f",
         "sha3_512": "a872d9efeb2a31fe92cf116e5ca8c9b57b07b200c91adc0a26ff58f32b5c2f5bd69671809e8a85383da8e51e6f64cc74af4470832bbbe17cde35391d4fb0fbe8",
         "shake_128": "d387bbb179a29a607bb86d119dfdab2f5961c254cedb7cbd9a8157c290d48812",
-        "shake_256": "db0b571b3252be360bf6d720f75bce209a75cdf4184db200cc9c72028b14e23a4527bf7d491e8fcf998a1bee474c2824930f8f9ab0ef4062120313f81a9e6774"
+        "shake_256": "db0b571b3252be360bf6d720f75bce209a75cdf4184db200cc9c72028b14e23a4527bf7d491e8fcf998a1bee474c2824930f8f9ab0ef4062120313f81a9e6774",
+        "ripemd160": "8ee2970b47aa341b39699bf52cce3e43a9b5e11c",
+        "sha512_256": "abe5f1fd1934c5c91ff5ba1912362402ee6c0cb79814898feee8dc07ffe85f95",
+        "sm3": "98226efe610707b79497cf6c08c270b6c2a7c60b5ab40cd3483da9cd3668b5f2",
+        "sha512_224": "a1af41114c501d2c30c1fe259d794e672dc66ae86b0e77173ae714fd",
+        "md5-sha1": "3de8f8b0dc94b8c2230fab9ec0ba050626d82f1931cbdbd83c2a6871b2cecd5cbcc8c26b"
     }
 
     def setUp(self):
@@ -76,6 +81,22 @@ class TestHasher(unittest.TestCase):
 
     def test_checksum_file_shake_256(self):
         self._test_checksum_file_with_algorithm("shake_256", length=64) 
+    
+    def test_checksum_fileripemd160(self):
+        self._test_checksum_file_with_algorithm("ripemd160")
+
+    def test_checksum_file_sha512_256(self):
+        self._test_checksum_file_with_algorithm("sha512_256")
+
+    def test_checksum_file_sm3(self):
+        self._test_checksum_file_with_algorithm("sm3")
+
+    def test_checksum_file_sha512_224(self):
+        self._test_checksum_file_with_algorithm("sha512_224")
+
+    def test_checksum_file_md5_sha1(self):
+        self._test_checksum_file_with_algorithm("md5-sha1")
+        
 
     def _test_checksum_file_with_algorithm(self, algorithm="md5", length=None):
         expected_checksum = self.checksums[algorithm]
@@ -84,6 +105,18 @@ class TestHasher(unittest.TestCase):
         else:
             checksum = self.hasher.checksum_file(self.temp_file_path, algorithm=algorithm)
         self.assertEqual(checksum, expected_checksum)
+
+    def test_algorithms_coverage(self):
+        algorithms_available = hashlib.algorithms_available
+        algorithms_covered = set(self.checksums.keys())
+        
+        # Print the available algorithms and covered algorithms
+        print(f"algorithms_available: {algorithms_available}")
+        print(f"algorithms_covered: {algorithms_covered}")
+        
+        # Ensure exact match between available algorithms and covered algorithms
+        self.assertEqual(algorithms_covered, algorithms_available, 
+                        "The algorithms in checksums do not exactly match the available algorithms in hashlib")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_hasher.py
+++ b/tests/test_hasher.py
@@ -1,0 +1,91 @@
+import hashlib
+import os
+import tempfile
+import unittest
+from sumbuddy.hasher import Hasher
+
+class TestHasher(unittest.TestCase):
+    checksums = {
+        "md5": "3de8f8b0dc94b8c2230fab9ec0ba0506",
+        "sha1": "26d82f1931cbdbd83c2a6871b2cecd5cbcc8c26b",
+        "sha224": "47bc9874c3715f9f4b6b63d10b87803e2adb564ae88f3912975542c8",
+        "sha256": "f29bc64a9d3732b4b9035125fdb3285f5b6455778edca72414671e0ca3b2e0de",
+        "sha384": "ae5dd957590ab86fd7359f43ecb68b8734d501271ca2d3953b7209ed63a98dfb86cf66e2c5848cc2471abdd80578670a",
+        "sha512": "b1df216b5b05e3965c469492744a5de0c945e0b103c42eb1e57476fbed8f1d489f5cae9b792db37c5d823bc0c6c7d06b056176d6abe5ce076eeadaed414e17a3",
+        "blake2b": "d7d25714b54ae8e63105f3a445ae2ac575b1540dc6070e1228d5eba0f461f8e27af66716dc8d73d7f85f7c55a17c2e97ec8ab6caaef3e98380605044a1e53575",
+        "blake2s": "68dfdbcbbaa3b8447adeb0634e1329ce74142bd673589ed7f3e6db910132a15d",
+        "sha3_224": "02f482b6fc8462a98f65224e81eb5425bd2157a02e7e64912fb39df1",
+        "sha3_256": "aa49cf654dc0b2a9ee97890fb81c6d898c5c03f441baaf2f1c9adffe00d3e561",
+        "sha3_384": "1c635201d12b87839b626b26c57b81216d616c984dc42d5afa17a905402267817ac787abfc24072e18e77f921eb6a23f",
+        "sha3_512": "a872d9efeb2a31fe92cf116e5ca8c9b57b07b200c91adc0a26ff58f32b5c2f5bd69671809e8a85383da8e51e6f64cc74af4470832bbbe17cde35391d4fb0fbe8",
+        "shake_128": "d387bbb179a29a607bb86d119dfdab2f5961c254cedb7cbd9a8157c290d48812",  
+        "shake_256": "db0b571b3252be360bf6d720f75bce209a75cdf4184db200cc9c72028b14e23a4527bf7d491e8fcf998a1bee474c2824930f8f9ab0ef4062120313f81a9e6774"
+    }
+
+    def setUp(self):
+        self.hasher = Hasher()
+        self.temp_file = tempfile.NamedTemporaryFile(delete=False)
+        self.temp_file.write(b'This is a test file.')
+        self.temp_file_path = self.temp_file.name
+        self.temp_file.close()
+
+    def tearDown(self):
+        os.remove(self.temp_file_path)
+
+    def test_checksum_file(self):
+        self._test_checksum_file_with_algorithm()
+
+    def test_checksum_file_md5(self):
+        self._test_checksum_file_with_algorithm("md5")
+
+    def test_checksum_file_sha1(self):
+        self._test_checksum_file_with_algorithm("sha1")
+
+    def test_checksum_file_sha224(self):
+        self._test_checksum_file_with_algorithm("sha224")
+
+    def test_checksum_file_sha256(self):
+        self._test_checksum_file_with_algorithm("sha256")
+
+    def test_checksum_file_sha384(self):
+        self._test_checksum_file_with_algorithm("sha384")
+
+    def test_checksum_file_sha512(self):
+        self._test_checksum_file_with_algorithm("sha512")
+
+    def test_checksum_file_blake2b(self):
+        self._test_checksum_file_with_algorithm("blake2b")
+
+    def test_checksum_file_blake2s(self):
+        self._test_checksum_file_with_algorithm("blake2s")
+
+    def test_checksum_file_sha3_224(self):
+        self._test_checksum_file_with_algorithm("sha3_224")
+
+    def test_checksum_file_sha3_256(self):
+        self._test_checksum_file_with_algorithm("sha3_256")
+
+    def test_checksum_file_sha3_384(self):
+        self._test_checksum_file_with_algorithm("sha3_384")
+
+    def test_checksum_file_sha3_512(self):
+        self._test_checksum_file_with_algorithm("sha3_512")
+
+    def test_checksum_file_shake_128(self):
+        self._test_checksum_file_with_algorithm("shake_128", length=32) 
+
+    def test_checksum_file_shake_256(self):
+        self._test_checksum_file_with_algorithm("shake_256", length=64) 
+
+    def _test_checksum_file_with_algorithm(self, algorithm="md5", length=None):
+        expected_checksum = self.checksums[algorithm]
+        if length:
+            checksum = self.hasher.checksum_file(self.temp_file_path, algorithm=algorithm)
+            checksum = checksum[:length]
+        else:
+            checksum = self.hasher.checksum_file(self.temp_file_path, algorithm=algorithm)
+        self.assertEqual(checksum, expected_checksum)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/test_hasher.py
+++ b/tests/test_hasher.py
@@ -5,6 +5,16 @@ import unittest
 from sumbuddy.hasher import Hasher
 
 class TestHasher(unittest.TestCase):
+    """
+    Correct answers generated with (where items in [square brackets] are optional depending on the algorithm): 
+    with open('test_file.txt', "wb") as f:
+        file.write(b'This is a test file.')
+    hash_func = hashlib.new('<algorithm>', [digest_size=<length>])
+    with open('test_file.txt', "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            hash_func.update(chunk)
+    hash_func.hexdigest([<length>])
+    """
     checksums = {
         "md5": "3de8f8b0dc94b8c2230fab9ec0ba0506",
         "sha1": "26d82f1931cbdbd83c2a6871b2cecd5cbcc8c26b",
@@ -110,11 +120,6 @@ class TestHasher(unittest.TestCase):
         algorithms_available = hashlib.algorithms_available
         algorithms_covered = set(self.checksums.keys())
         
-        # Print the available algorithms and covered algorithms
-        print(f"algorithms_available: {algorithms_available}")
-        print(f"algorithms_covered: {algorithms_covered}")
-        
-        # Ensure exact match between available algorithms and covered algorithms
         self.assertEqual(algorithms_covered, algorithms_available, 
                         "The algorithms in checksums do not exactly match the available algorithms in hashlib")
 

--- a/tests/test_hasher.py
+++ b/tests/test_hasher.py
@@ -106,7 +106,14 @@ class TestHasher(unittest.TestCase):
 
     def test_checksum_file_md5_sha1(self):
         self._test_checksum_file_with_algorithm("md5-sha1")
-        
+
+    def test_invalid_length_for_fixed_length_algorithm(self):
+        with self.assertRaises(ValueError):
+            self.hasher.checksum_file(self.temp_file_path, algorithm="md5", length=10)
+
+    def test_nonexistent_file(self):
+        with self.assertRaises(FileNotFoundError):
+            self.hasher.checksum_file("non_existent_file.txt", algorithm="md5")   
 
     def _test_checksum_file_with_algorithm(self, algorithm="md5", length=None):
         expected_checksum = self.checksums[algorithm]

--- a/tests/test_hasher.py
+++ b/tests/test_hasher.py
@@ -18,7 +18,7 @@ class TestHasher(unittest.TestCase):
         "sha3_256": "aa49cf654dc0b2a9ee97890fb81c6d898c5c03f441baaf2f1c9adffe00d3e561",
         "sha3_384": "1c635201d12b87839b626b26c57b81216d616c984dc42d5afa17a905402267817ac787abfc24072e18e77f921eb6a23f",
         "sha3_512": "a872d9efeb2a31fe92cf116e5ca8c9b57b07b200c91adc0a26ff58f32b5c2f5bd69671809e8a85383da8e51e6f64cc74af4470832bbbe17cde35391d4fb0fbe8",
-        "shake_128": "d387bbb179a29a607bb86d119dfdab2f5961c254cedb7cbd9a8157c290d48812",  
+        "shake_128": "d387bbb179a29a607bb86d119dfdab2f5961c254cedb7cbd9a8157c290d48812",
         "shake_256": "db0b571b3252be360bf6d720f75bce209a75cdf4184db200cc9c72028b14e23a4527bf7d491e8fcf998a1bee474c2824930f8f9ab0ef4062120313f81a9e6774"
     }
 
@@ -80,12 +80,10 @@ class TestHasher(unittest.TestCase):
     def _test_checksum_file_with_algorithm(self, algorithm="md5", length=None):
         expected_checksum = self.checksums[algorithm]
         if length:
-            checksum = self.hasher.checksum_file(self.temp_file_path, algorithm=algorithm)
-            checksum = checksum[:length]
+            checksum = self.hasher.checksum_file(self.temp_file_path, algorithm=algorithm, length=length)
         else:
             checksum = self.hasher.checksum_file(self.temp_file_path, algorithm=algorithm)
         self.assertEqual(checksum, expected_checksum)
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/test_hasher.py
+++ b/tests/test_hasher.py
@@ -74,6 +74,12 @@ class TestHasher(unittest.TestCase):
     def test_checksum_file_blake2s(self):
         self._test_checksum_file_with_algorithm("blake2s")
 
+    def test_checksum_file_blake2b_len(self):
+        self._test_checksum_file_with_algorithm("blake2b", length = 64)
+
+    def test_checksum_file_blake2s_len(self):
+        self._test_checksum_file_with_algorithm("blake2s", length = 32)
+
     def test_checksum_file_sha3_224(self):
         self._test_checksum_file_with_algorithm("sha3_224")
 

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -1,0 +1,72 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch, mock_open, MagicMock
+from sumbuddy.mapper import Mapper
+from sumbuddy.filter import Filter
+
+class TestMapper(unittest.TestCase):
+    @patch('sumbuddy.filter.open', new_callable=mock_open, read_data="# This is a sample ignore file\n")
+    def test_reset_filter(self, mock_file):
+        mapper = Mapper()
+        mapper.reset_filter()
+        self.assertIsInstance(mapper.filter_manager, Filter)
+        
+        mapper.reset_filter(ignore_file='ignore_file')
+        self.assertIsInstance(mapper.filter_manager, Filter)
+        
+        mapper.reset_filter(include_hidden=True)
+        self.assertIsInstance(mapper.filter_manager, Filter)
+        
+    def test_gather_file_paths(self):
+        mapper = Mapper()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            subdir_path = os.path.join(temp_dir, 'subdir')
+            os.makedirs(subdir_path, exist_ok=True)
+            with open(os.path.join(temp_dir, 'file1.txt'), 'w') as file:
+                file.write('Some content')
+            with open(os.path.join(temp_dir, 'file2.txt'), 'w') as file:
+                file.write('Some content')
+            with open(os.path.join(temp_dir, '.hidden.txt'), 'w') as file:
+                file.write('Some content')
+            with open(os.path.join(subdir_path, 'file3.txt'), 'w') as file:
+                file.write('Some content')
+            with open(os.path.join(subdir_path, '.hidden.txt'), 'w') as file:
+                file.write('Some content')
+            
+            file_paths = mapper.gather_file_paths(temp_dir)
+            self.assertEqual(len(file_paths), 3)
+            self.assertIn(os.path.join(temp_dir, 'file1.txt'), file_paths)
+            self.assertIn(os.path.join(temp_dir, 'file2.txt'), file_paths)
+            self.assertIn(os.path.join(subdir_path, 'file3.txt'), file_paths)
+            
+            # Create ignore file and test with it, if we ignore the .txt files, we will
+            # only have the ignore file in the list of file paths.
+            ignore_file_path = os.path.join(temp_dir, 'ignore_file')
+            with open(ignore_file_path, 'w') as ignore_file:
+                ignore_file.write("*.txt")
+
+            file_paths = mapper.gather_file_paths(temp_dir, ignore_file=ignore_file_path)
+            self.assertEqual(len(file_paths), 1)
+            self.assertIn(os.path.join(temp_dir, 'ignore_file'), file_paths)
+            
+            # Test including hidden files
+            file_paths = mapper.gather_file_paths(temp_dir, include_hidden=True)
+            self.assertEqual(len(file_paths), 6)
+            self.assertIn(os.path.join(temp_dir, 'file1.txt'), file_paths)
+            self.assertIn(os.path.join(temp_dir, 'file2.txt'), file_paths)
+            self.assertIn(os.path.join(temp_dir, 'ignore_file'), file_paths)
+            self.assertIn(os.path.join(temp_dir, '.hidden.txt'), file_paths)
+            self.assertIn(os.path.join(subdir_path, 'file3.txt'), file_paths)
+            self.assertIn(os.path.join(subdir_path, '.hidden.txt'), file_paths)
+            
+            file_paths = mapper.gather_file_paths(temp_dir)
+            self.assertEqual(len(file_paths), 4)
+            self.assertIn(os.path.join(temp_dir, 'file1.txt'), file_paths)
+            self.assertIn(os.path.join(temp_dir, 'file2.txt'), file_paths)
+            self.assertIn(os.path.join(temp_dir, 'ignore_file'), file_paths)
+            self.assertIn(os.path.join(subdir_path, 'file3.txt'), file_paths)
+           
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add more test cases for sum-buddy:
- test_mapper.py: This test file contains unit tests for the mapper module of the sum-buddy project. 
- test_hasher.py: This test file includes unit tests for the hasher module of the sum-buddy project. 
- test_getChecksums.py: This test file comprises unit tests for the get_checksums function in the sum-buddy project. 
- test_filter.py: This test file contains unit tests for the filter module of the sum-buddy project. 

Add tests #4 