### PR TITLE
Update Python dependency

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,11 +21,7 @@ jobs:
           python-version: ${{ matrix.python-version }} 
 
       - name: install dependencies
-        run: pip install .
-        shell: bash
-
-      - name: install pytest
-        run: pip install pytest
+        run: pip install .[dev]
         shell: bash
 
       - name: run test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,14 +7,18 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }} 
 
       - name: install dependencies
         run: pip install .

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Command-line package to generate a CSV with filepath, filename, and checksum for contents of a given directory or a single file.
 
 ## Requirements
-Python 3.7+
+Python 3.10+
 
 
 ## Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 description = "A command-line package to generate CSV with filepath, filename, checksum for all contents of given directory."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Removes support for 3.7-3.9 ([3.9 is approaching end of life](https://devguide.python.org/versions/), other two have been retired).

Updates testing workflow to check all supported Python versions, not just 3.12 (previously the highest). May adjust to distinct push (lowest & highest) and PR (all) tests if needed when Python 3.14 comes online if they become too time-consuming.