### PR TITLE
Handle linting

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,6 +24,10 @@ jobs:
         run: pip install pytest
         shell: bash
 
+      - name: run Ruff linter
+        run: ruff check .
+        shell: bash
+
       - name: run test
         run: pytest -rs
         shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.2
+    hooks:
+      - id: ruff
+

--- a/README.md
+++ b/README.md
@@ -160,3 +160,21 @@ file_paths = gather_file_paths(input_path, ignore_file=ignore_file)
 sum = checksum_file("examples/example_content/file.txt", algorithm=alg)
 # or sum = checksum_file("examples/example_content/file.txt")
 ```
+
+## Development
+To develop the package further:
+
+1. Clone the repository and create a branch
+2. Install with dev dependencies:
+```bash
+pip install -e .[dev]
+```
+3. Install pre-commit hook
+```bash
+pre-commit install
+pre-commit autoupdate # optionally update
+```
+4. Run tests:
+```bash
+pytest
+```

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ To develop the package further:
 1. Clone the repository and create a branch
 2. Install with dev dependencies:
 ```bash
-pip install -e .[dev]
+pip install -e ".[dev]"
 ```
 3. Install pre-commit hook
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,11 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest"]
+dev = [
+  "pytest",
+  "ruff",
+  "pre-commit"
+]
 
 keywords = [
   "checksum",

--- a/src/sumbuddy/__main__.py
+++ b/src/sumbuddy/__main__.py
@@ -1,7 +1,6 @@
 import argparse
 from sumbuddy.hasher import Hasher
 from sumbuddy.mapper import Mapper
-from sumbuddy.filter import Filter
 from sumbuddy.exceptions import EmptyInputDirectoryError, NoFilesAfterFilteringError, LengthUsedForFixedLengthHashError
 import csv
 import hashlib

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,7 +1,7 @@
 
 import unittest
 import os
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from sumbuddy.filter import Filter
 from sumbuddy.hasher import Hasher
 

--- a/tests/test_getChecksums.py
+++ b/tests/test_getChecksums.py
@@ -1,8 +1,6 @@
 import unittest
-from unittest.mock import patch, mock_open, MagicMock
+from unittest.mock import patch, mock_open
 import os
-import sys
-import hashlib
 from io import StringIO
 
 from sumbuddy import get_checksums

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
 import unittest
-from unittest.mock import patch, mock_open, MagicMock
+from unittest.mock import patch, mock_open
 from sumbuddy.mapper import Mapper
 from sumbuddy.filter import Filter
 from sumbuddy.exceptions import EmptyInputDirectoryError, NoFilesAfterFilteringError, NotADirectoryError


### PR DESCRIPTION
Run ruff; remove unused imports; add ruff and pre-commit to dev dependencies; add linter pre-commit hook; update README for developers; add lint check to GitHub workflow

This PR integrates `ruff check .` to enforce lightweight, non-opinionated linting.
Focus is on code hygiene without dictating style. 
Complimentary to `pytest` , catching issues including:

- Unused imports and variables
- Leftover debugging statements (`print`, `breakpoint`)
- Redundant or unreachable code

Only `ruff check` (not `ruff format`) is used in the pre-commit hook and CI here.
