### PR TITLE
Add Citation and Zenodo metadata

### DIFF
--- a/.github/workflows/validate-zenodo.yaml
+++ b/.github/workflows/validate-zenodo.yaml
@@ -1,0 +1,19 @@
+name: Check zenodo metadata
+
+on: [push]
+
+jobs:
+  check-zenodo-metadata:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install dependencies
+        run: npm install zenodraft@0.14.1
+      - name: Check .zenodo.json file
+        run: |
+          npx zenodraft metadata validate .zenodo.json 

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,42 @@
+{
+  "creators": [
+    {
+      "name": "Thompson, Matthew J.",
+      "orcid": "0000-0003-0583-8585"
+    },
+    {
+      "name": "Campolongo, Elizabeth G.",
+      "orcid": "0000-0003-0846-2413"
+    },
+    {
+      "name": "Duan, Zoe",
+      "orcid": "0000-0002-8547-5907"
+    },
+    {
+      "name": "Lapp, Hilmar",
+      "orcid": "0000-0001-9107-0714"
+    }
+  ],
+  "description": "A command-line package to generate CSV with filepath, filename, checksum for all contents of given directory.",
+  "keywords": [
+    "imageomics",
+    "metadata",
+    "CSV",
+    "images",
+    "verifier",
+    "checksums",
+    "file-verification",
+    "deduplication"
+  ],
+  "license": {
+    "id": "MIT"
+  },
+  "publication_date": "2025-04-03",
+  "title": "Sum Buddy",
+  "version": "1.0.0",
+  "grants": [
+      {
+          "id": "021nxhr62::2118240"
+        }
+    ]
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,39 @@
+abstract: "A command-line package to generate CSV with filepath, filename, checksum for all contents of given directory."
+authors:
+- family-names: "Thompson"
+  given-names: "Matthew J."
+  orcid: "https://orcid.org/0000-0003-0583-8585"
+- family-names: "Campolongo"
+  given-names: "Elizabeth G."
+  orcid: "https://orcid.org/0000-0003-0846-2413"
+- family-names: "Zoe"
+  given-names: "Duan"
+  orcid: "https://orcid.org/0000-0002-8547-5907"
+- family-names: "Lapp"
+  given-names: "Hilmar"
+  orcid: "https://orcid.org/0000-0001-9107-0714"
+cff-version: 1.2.0
+date-released: "2024-07-30"
+identifiers:
+  - description: "The GitHub release URL of tag v0.2.0-alpha."
+    type: url
+    value: "https://github.com/Imageomics/sum-buddy/releases/tag/v0.2.0-alpha"
+  - description: "The GitHub URL of the commit tagged with v0.2.0-alpha."
+    type: url
+    value: "https://github.com/Imageomics/sum-buddy/tree/2a29e34ecf98d25c6ca4d5665e2b0929fe9cfb48"
+keywords:
+  - imageomics
+  - metadata
+  - CSV
+  - images
+  - verifier
+  - checksums
+  - file-verification
+  - deduplication
+license: MIT
+message: "If you use this software, please cite it using the metadata from this file."
+repository-code: "https://github.com/Imageomics/sum-buddy"
+title: "Sum Buddy"
+version: "0.2.0-alpha"
+# doi: <DOI from Zenodo>
+type: software

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,14 +13,14 @@ authors:
   given-names: "Hilmar"
   orcid: "https://orcid.org/0000-0001-9107-0714"
 cff-version: 1.2.0
-date-released: "2024-07-30"
+date-released: "2025-04-03"
 identifiers:
-  - description: "The GitHub release URL of tag v0.2.0-alpha."
+  - description: "The GitHub release URL of tag v1.0.0."
     type: url
-    value: "https://github.com/Imageomics/sum-buddy/releases/tag/v0.2.0-alpha"
-  - description: "The GitHub URL of the commit tagged with v0.2.0-alpha."
+    value: "https://github.com/Imageomics/sum-buddy/releases/tag/v1.0.0"
+  - description: "The GitHub URL of the commit tagged with v1.0.0."
     type: url
-    value: "https://github.com/Imageomics/sum-buddy/tree/2a29e34ecf98d25c6ca4d5665e2b0929fe9cfb48"
+    value: "https://github.com/Imageomics/sum-buddy/tree/<commit hash>"  #update on release
 keywords:
   - imageomics
   - metadata
@@ -34,6 +34,6 @@ license: MIT
 message: "If you use this software, please cite it using the metadata from this file."
 repository-code: "https://github.com/Imageomics/sum-buddy"
 title: "Sum Buddy"
-version: "0.2.0-alpha"
+version: "1.0.0"
 # doi: <DOI from Zenodo>
 type: software

--- a/src/sumbuddy/__about__.py
+++ b/src/sumbuddy/__about__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2.0-alpha"
+__version__ = "1.0.0"


### PR DESCRIPTION
Adds a `CITATION.cff`, the `.zenodo.json` to ensure metadata is added and maintained with Zenodo sync, and a test to ensure the Zenodo metadata file is valid.