### PR TITLE
Normalize input paths in checksum output

### DIFF
--- a/src/sumbuddy/__main__.py
+++ b/src/sumbuddy/__main__.py
@@ -26,7 +26,7 @@ def get_checksums(input_path, output_filepath=None, ignore_file=None, include_hi
     mapper = Mapper()
 
     if os.path.isfile(input_path):
-        regular_files = [input_path]
+        regular_files = [os.path.normpath(input_path)]
         archive_files = []
         if ignore_file:
             print("Warning: --ignore-file (-i) flag is ignored when input is a single file.")

--- a/src/sumbuddy/mapper.py
+++ b/src/sumbuddy/mapper.py
@@ -57,7 +57,7 @@ class Mapper:
             if files:
                 has_files = True
             for name in files:
-                file_path = os.path.join(root, name)
+                file_path = os.path.normpath(os.path.join(root, name))
                 if self.filter_manager.should_include(file_path, root_directory):
                     if self.archive_handler.is_supported_archive(file_path):
                         archive_files.append(file_path)

--- a/tests/test_getChecksums.py
+++ b/tests/test_getChecksums.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch, mock_open
 import os
+import tempfile
 from io import StringIO
 
 from sumbuddy import get_checksums
@@ -37,6 +38,51 @@ class TestGetChecksums(unittest.TestCase):
         output = output_stream.getvalue()
         self.assertIn('filepath,filename,md5', output)
         self.assertIn(f'{self.input_path},{os.path.basename(self.input_path)},dummychecksum', output)
+
+    @patch('sumbuddy.Hasher.checksum_file', return_value='dummychecksum')
+    def test_get_checksums_normalizes_dot_directory_paths_in_stdout(self, mock_checksum):
+        output_stream = StringIO()
+        original_cwd = os.getcwd()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            os.makedirs(os.path.join(temp_dir, 'subdir'), exist_ok=True)
+            with open(os.path.join(temp_dir, 'file1.txt'), 'w') as file:
+                file.write('Some content')
+            with open(os.path.join(temp_dir, 'subdir', 'file2.txt'), 'w') as file:
+                file.write('Some content')
+
+            try:
+                os.chdir(temp_dir)
+                with patch('sys.stdout', new=output_stream):
+                    get_checksums('.', output_filepath=None, ignore_file=None, include_hidden=False, algorithm=self.algorithm)
+            finally:
+                os.chdir(original_cwd)
+
+        output = output_stream.getvalue()
+        self.assertIn('file1.txt,file1.txt,dummychecksum', output)
+        self.assertIn('subdir/file2.txt,file2.txt,dummychecksum', output)
+        self.assertNotIn('./file1.txt,', output)
+        self.assertNotIn('./subdir/file2.txt,', output)
+
+    @patch('sumbuddy.Hasher.checksum_file', return_value='dummychecksum')
+    def test_get_checksums_normalizes_dot_single_file_path_in_stdout(self, mock_checksum):
+        output_stream = StringIO()
+        original_cwd = os.getcwd()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with open(os.path.join(temp_dir, 'file1.txt'), 'w') as file:
+                file.write('Some content')
+
+            try:
+                os.chdir(temp_dir)
+                with patch('sys.stdout', new=output_stream):
+                    get_checksums('./file1.txt', output_filepath=None, ignore_file=None, include_hidden=False, algorithm=self.algorithm)
+            finally:
+                os.chdir(original_cwd)
+
+        output = output_stream.getvalue()
+        self.assertIn('file1.txt,file1.txt,dummychecksum', output)
+        self.assertNotIn('./file1.txt,', output)
 
     @patch('os.path.abspath', side_effect=lambda x: x)
     @patch('os.path.exists', return_value=True)

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -96,7 +96,6 @@ class TestMapper(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as temp_file:
             with self.assertRaises(NotADirectoryError):
                 mapper.gather_file_paths(temp_file.name)
-           
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Addresses #38   

Old behavior:

  - inputs like `.`, `./file`, etc. would be emitted with leading `./`

  New behavior:

  - normalize paths before output
  
Side note ... for ZIP archives, outer archive paths are now normalized, but inner member paths are unchanged and come out as `<norm-archive-path>/<literal-member-path>`.

It's better to report literally what's in the archive file.
